### PR TITLE
fix: use v prefix for version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,5 +37,5 @@ jobs:
     - name: Create new version
       if: ${{ steps.get_next_version.outputs.hasNextVersion == 'true' }}
       run: |
-        git tag ${{steps.get_next_version.outputs.version}}
-        git push origin ${{steps.get_next_version.outputs.version}}
+        git tag v${{steps.get_next_version.outputs.version}}
+        git push origin v${{steps.get_next_version.outputs.version}}


### PR DESCRIPTION
The version needs to start with `v`, otherwise go mod can't resolve the tag correctly.
https://go.dev/ref/mod#versions