### PR TITLE
fix: correctly dispatch json marshalling on event candidates

### DIFF
--- a/event_candidate.go
+++ b/event_candidate.go
@@ -1,5 +1,7 @@
 package eventsourcingdb
 
+import "encoding/json"
+
 type EventCandidateMetadata struct {
 	StreamName string
 	Name       string
@@ -12,13 +14,31 @@ func NewEventCandidateMetadata(streamName, name string) EventCandidateMetadata {
 	}
 }
 
-type EventCandidate struct {
-	Metadata EventCandidateMetadata
-	Data     interface{}
+type EventCandidate interface {
+	Metadata() EventCandidateMetadata
+	Data() json.RawMessage
 }
 
-func NewEventCandidate(streamName, name string, data interface{}) EventCandidate {
-	return EventCandidate{
+type eventCandidate[TData any] struct {
+	metadata EventCandidateMetadata
+	data     TData
+}
+
+func (candidate eventCandidate[TData]) Metadata() EventCandidateMetadata {
+	return candidate.metadata
+}
+
+func (candidate eventCandidate[TData]) Data() json.RawMessage {
+	data, err := json.Marshal(candidate.data)
+	if err != nil {
+		panic(err)
+	}
+
+	return data
+}
+
+func NewEventCandidate[TData any](streamName, name string, data TData) EventCandidate {
+	return eventCandidate[TData]{
 		NewEventCandidateMetadata(streamName, name),
 		data,
 	}

--- a/observe_events_test.go
+++ b/observe_events_test.go
@@ -43,36 +43,28 @@ func TestObserveEvents(t *testing.T) {
 		return data.Event
 	}
 
-	matchRegisteredEvent := func(t *testing.T, event eventsourcingdb.Event, candidate eventsourcingdb.EventCandidate) {
-		assert.Equal(t, event.Metadata.StreamName, candidate.Metadata.StreamName)
-		assert.Equal(t, event.Metadata.Name, candidate.Metadata.Name)
+	matchRegisteredEvent := func(t *testing.T, event eventsourcingdb.Event, expected test.RegisteredEvent) {
+		assert.Equal(t, "/users/registered", event.Metadata.StreamName)
+		assert.Equal(t, expected.Name, event.Metadata.Name)
 
 		var eventData test.RegisteredEventData
 		err := json.Unmarshal(event.Data, &eventData)
 
 		assert.NoError(t, err)
 
-		candidateData, ok := candidate.Data.(test.RegisteredEventData)
-
-		assert.True(t, ok)
-
-		assert.Equal(t, candidateData.Name, eventData.Name)
+		assert.Equal(t, expected.Data.Name, eventData.Name)
 	}
 
-	matchLoggedInEvent := func(t *testing.T, event eventsourcingdb.Event, candidate eventsourcingdb.EventCandidate) {
-		assert.Equal(t, event.Metadata.StreamName, candidate.Metadata.StreamName)
-		assert.Equal(t, event.Metadata.Name, candidate.Metadata.Name)
+	matchLoggedInEvent := func(t *testing.T, event eventsourcingdb.Event, expected test.LoggedInEvent) {
+		assert.Equal(t, "/users/loggedIn", event.Metadata.StreamName)
+		assert.Equal(t, expected.Name, event.Metadata.Name)
 
 		var eventData test.LoggedInEventData
 		err := json.Unmarshal(event.Data, &eventData)
 
 		assert.NoError(t, err)
 
-		candidateData, ok := candidate.Data.(test.LoggedInEventData)
-
-		assert.True(t, ok)
-
-		assert.Equal(t, candidateData.Name, eventData.Name)
+		assert.Equal(t, expected.Data.Name, eventData.Name)
 	}
 
 	t.Run("returns an error when trying to observe from a non-reachable server.", func(t *testing.T) {
@@ -108,10 +100,10 @@ func TestObserveEvents(t *testing.T) {
 		resultChan := client.ObserveEvents(ctx, "/users/registered", false)
 
 		firstEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, firstEvent, janeRegistered)
+		matchRegisteredEvent(t, firstEvent, test.Events.Registered.JaneDoe)
 
 		secondEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, secondEvent, johnRegistered)
+		matchRegisteredEvent(t, secondEvent, test.Events.Registered.JohnDoe)
 
 		apfelFredCandidate := eventsourcingdb.NewEventCandidate(
 			"/users/registered",
@@ -124,7 +116,7 @@ func TestObserveEvents(t *testing.T) {
 
 		assert.NoError(t, err)
 		thirdEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, thirdEvent, apfelFredCandidate)
+		matchRegisteredEvent(t, thirdEvent, test.Events.Registered.ApfelFred)
 	})
 
 	t.Run("observes from a stream including sub-streams.", func(t *testing.T) {
@@ -139,16 +131,16 @@ func TestObserveEvents(t *testing.T) {
 		)
 
 		firstEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, firstEvent, janeRegistered)
+		matchRegisteredEvent(t, firstEvent, test.Events.Registered.JaneDoe)
 
 		secondEvent := getNextEvent(t, resultChan)
-		matchLoggedInEvent(t, secondEvent, janeLoggedIn)
+		matchLoggedInEvent(t, secondEvent, test.Events.LoggedIn.JaneDoe)
 
 		thirdEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, thirdEvent, johnRegistered)
+		matchRegisteredEvent(t, thirdEvent, test.Events.Registered.JohnDoe)
 
 		fourthEvent := getNextEvent(t, resultChan)
-		matchLoggedInEvent(t, fourthEvent, johnLoggedIn)
+		matchLoggedInEvent(t, fourthEvent, test.Events.LoggedIn.JohnDoe)
 	})
 
 	t.Run("observes events starting from the newest event matching the given event name.", func(t *testing.T) {
@@ -168,7 +160,7 @@ func TestObserveEvents(t *testing.T) {
 		)
 
 		secondEvent := getNextEvent(t, resultChan)
-		matchLoggedInEvent(t, secondEvent, johnLoggedIn)
+		matchLoggedInEvent(t, secondEvent, test.Events.LoggedIn.JohnDoe)
 	})
 
 	t.Run("observes events starting from the lower bound ID.", func(t *testing.T) {
@@ -184,10 +176,10 @@ func TestObserveEvents(t *testing.T) {
 		)
 
 		firstEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, firstEvent, johnRegistered)
+		matchRegisteredEvent(t, firstEvent, test.Events.Registered.JohnDoe)
 
 		secondEvent := getNextEvent(t, resultChan)
-		matchLoggedInEvent(t, secondEvent, johnLoggedIn)
+		matchLoggedInEvent(t, secondEvent, test.Events.LoggedIn.JohnDoe)
 	})
 
 	t.Run("returns a ContextCanceledError when the context is canceled.", func(t *testing.T) {

--- a/read_events_test.go
+++ b/read_events_test.go
@@ -37,36 +37,28 @@ func TestReadEvents(t *testing.T) {
 		return data.Event
 	}
 
-	matchRegisteredEvent := func(t *testing.T, event eventsourcingdb.Event, candidate eventsourcingdb.EventCandidate) {
-		assert.Equal(t, event.Metadata.StreamName, candidate.Metadata.StreamName)
-		assert.Equal(t, event.Metadata.Name, candidate.Metadata.Name)
+	matchRegisteredEvent := func(t *testing.T, event eventsourcingdb.Event, expected test.RegisteredEvent) {
+		assert.Equal(t, "/users/registered", event.Metadata.StreamName)
+		assert.Equal(t, expected.Name, event.Metadata.Name)
 
 		var eventData test.RegisteredEventData
 		err = json.Unmarshal(event.Data, &eventData)
 
 		assert.NoError(t, err)
 
-		candidateData, ok := candidate.Data.(test.RegisteredEventData)
-
-		assert.True(t, ok)
-
-		assert.Equal(t, candidateData.Name, eventData.Name)
+		assert.Equal(t, expected.Data.Name, eventData.Name)
 	}
 
-	matchLoggedInEvent := func(t *testing.T, event eventsourcingdb.Event, candidate eventsourcingdb.EventCandidate) {
-		assert.Equal(t, event.Metadata.StreamName, candidate.Metadata.StreamName)
-		assert.Equal(t, event.Metadata.Name, candidate.Metadata.Name)
+	matchLoggedInEvent := func(t *testing.T, event eventsourcingdb.Event, expected test.LoggedInEvent) {
+		assert.Equal(t, "/users/loggedIn", event.Metadata.StreamName)
+		assert.Equal(t, expected.Name, event.Metadata.Name)
 
 		var eventData test.LoggedInEventData
 		err = json.Unmarshal(event.Data, &eventData)
 
 		assert.NoError(t, err)
 
-		candidateData, ok := candidate.Data.(test.LoggedInEventData)
-
-		assert.True(t, ok)
-
-		assert.Equal(t, candidateData.Name, eventData.Name)
+		assert.Equal(t, expected.Data.Name, eventData.Name)
 	}
 
 	t.Run("returns an error when trying to read from a non-reachable server.", func(t *testing.T) {
@@ -94,10 +86,10 @@ func TestReadEvents(t *testing.T) {
 		resultChan := client.ReadEvents(context.Background(), "/users/registered", false)
 
 		firstEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, firstEvent, janeRegistered)
+		matchRegisteredEvent(t, firstEvent, test.Events.Registered.JaneDoe)
 
 		secondEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, secondEvent, johnRegistered)
+		matchRegisteredEvent(t, secondEvent, test.Events.Registered.JohnDoe)
 
 		data, ok := <-resultChan
 
@@ -112,16 +104,16 @@ func TestReadEvents(t *testing.T) {
 		)
 
 		firstEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, firstEvent, janeRegistered)
+		matchRegisteredEvent(t, firstEvent, test.Events.Registered.JaneDoe)
 
 		secondEvent := getNextEvent(t, resultChan)
-		matchLoggedInEvent(t, secondEvent, janeLoggedIn)
+		matchLoggedInEvent(t, secondEvent, test.Events.LoggedIn.JaneDoe)
 
 		thirdEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, thirdEvent, johnRegistered)
+		matchRegisteredEvent(t, thirdEvent, test.Events.Registered.JohnDoe)
 
 		fourthEvent := getNextEvent(t, resultChan)
-		matchLoggedInEvent(t, fourthEvent, johnLoggedIn)
+		matchLoggedInEvent(t, fourthEvent, test.Events.LoggedIn.JohnDoe)
 
 		data, ok := <-resultChan
 
@@ -137,10 +129,10 @@ func TestReadEvents(t *testing.T) {
 		)
 
 		firstEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, firstEvent, johnRegistered)
+		matchRegisteredEvent(t, firstEvent, test.Events.Registered.JohnDoe)
 
 		secondEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, secondEvent, janeRegistered)
+		matchRegisteredEvent(t, secondEvent, test.Events.Registered.JaneDoe)
 
 		data, ok := <-resultChan
 
@@ -160,7 +152,7 @@ func TestReadEvents(t *testing.T) {
 		)
 
 		firstEvent := getNextEvent(t, resultChan)
-		matchLoggedInEvent(t, firstEvent, johnLoggedIn)
+		matchLoggedInEvent(t, firstEvent, test.Events.LoggedIn.JohnDoe)
 
 		data, ok := <-resultChan
 
@@ -176,10 +168,10 @@ func TestReadEvents(t *testing.T) {
 		)
 
 		firstEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, firstEvent, johnRegistered)
+		matchRegisteredEvent(t, firstEvent, test.Events.Registered.JohnDoe)
 
 		secondEvent := getNextEvent(t, resultChan)
-		matchLoggedInEvent(t, secondEvent, johnLoggedIn)
+		matchLoggedInEvent(t, secondEvent, test.Events.LoggedIn.JohnDoe)
 
 		data, ok := <-resultChan
 
@@ -195,10 +187,10 @@ func TestReadEvents(t *testing.T) {
 		)
 
 		firstEvent := getNextEvent(t, resultChan)
-		matchRegisteredEvent(t, firstEvent, janeRegistered)
+		matchRegisteredEvent(t, firstEvent, test.Events.Registered.JaneDoe)
 
 		secondEvent := getNextEvent(t, resultChan)
-		matchLoggedInEvent(t, secondEvent, janeLoggedIn)
+		matchLoggedInEvent(t, secondEvent, test.Events.LoggedIn.JaneDoe)
 
 		data, ok := <-resultChan
 

--- a/test/events.go
+++ b/test/events.go
@@ -4,29 +4,29 @@ type RegisteredEventData struct {
 	Name string `json:"name"`
 }
 
-type registeredEvent struct {
+type RegisteredEvent struct {
 	Name string
 	Data RegisteredEventData
 }
 
 type registeredEvents struct {
-	JaneDoe   registeredEvent
-	JohnDoe   registeredEvent
-	ApfelFred registeredEvent
+	JaneDoe   RegisteredEvent
+	JohnDoe   RegisteredEvent
+	ApfelFred RegisteredEvent
 }
 
 type LoggedInEventData struct {
 	Name string `json:"name"`
 }
 
-type loggedInEvent struct {
+type LoggedInEvent struct {
 	Name string
 	Data LoggedInEventData
 }
 
 type loggedInEvents struct {
-	JaneDoe loggedInEvent
-	JohnDoe loggedInEvent
+	JaneDoe LoggedInEvent
+	JohnDoe LoggedInEvent
 }
 
 type events struct {
@@ -36,12 +36,12 @@ type events struct {
 
 var Events = events{
 	Registered: registeredEvents{
-		JaneDoe:   registeredEvent{"registered", RegisteredEventData{"Jane Doe"}},
-		JohnDoe:   registeredEvent{"registered", RegisteredEventData{"John Doe"}},
-		ApfelFred: registeredEvent{"registered", RegisteredEventData{"Apfel Fred"}},
+		JaneDoe:   RegisteredEvent{"registered", RegisteredEventData{"Jane Doe"}},
+		JohnDoe:   RegisteredEvent{"registered", RegisteredEventData{"John Doe"}},
+		ApfelFred: RegisteredEvent{"registered", RegisteredEventData{"Apfel Fred"}},
 	},
 	LoggedIn: loggedInEvents{
-		JaneDoe: loggedInEvent{"loggedIn", LoggedInEventData{"Jane Doe"}},
-		JohnDoe: loggedInEvent{"loggedIn", LoggedInEventData{"Jane Doe"}},
+		JaneDoe: LoggedInEvent{"loggedIn", LoggedInEventData{"Jane Doe"}},
+		JohnDoe: LoggedInEvent{"loggedIn", LoggedInEventData{"Jane Doe"}},
 	},
 }

--- a/write_events.go
+++ b/write_events.go
@@ -40,10 +40,10 @@ func (client *Client) WriteEventsWithPreconditions(preconditions *Preconditions,
 	for _, event := range eventCandidates {
 		requestBody.Events = append(requestBody.Events, writeEventsRequestBodyEventCandidate{
 			writeEventsRequestBodyEventCandidateMetadata{
-				event.Metadata.StreamName,
-				event.Metadata.Name,
+				event.Metadata().StreamName,
+				event.Metadata().Name,
 			},
-			event.Data,
+			event.Data(),
 		})
 	}
 


### PR DESCRIPTION
Previously, we used a struct type for `EventCandidate` received by `WriteEvents`. This type included a `Data` member of type `interface{}`. When calling `json.Marshal` on this `Data`, golang will dispatch a generic marshalling method, because it can't resolve any overrides of `MarshalJSON` on the data, as the type `interface{}` has no reference to custom structs of the user.

This would cause our json marshalling to ignore custom marshalling implementations.

To solve this, we changed `EventCandidate` to be an interface that return the already marshalled `Data`, and provided a generic `eventCandidate` struct that is generic and can be used with `NewEventCandidate` to create an `EventCandidate` with dynamic dispatch.