### PR TITLE
chore: Log docker stderr when test setup fails.

### DIFF
--- a/docker/image.go
+++ b/docker/image.go
@@ -48,7 +48,7 @@ func (image Image) Run(command []string, detached, exposePorts bool) (Container,
 		if exitError, ok := err.(*exec.ExitError); ok {
 			return Container{}, fmt.Errorf("failed to run image: %s", exitError.Stderr)
 		}
-		return Container{}, fmt.Errorf("failed to run image: %s", stderr)
+		return Container{}, err
 	}
 
 	containerID := strings.TrimSpace(string(stdout))


### PR DESCRIPTION
I'm not sure this change is enough to fulfill #37.

This change logs the stderr from calls to `docker build` and `docker run` in a way that adds context to failing tests. We can now see when building an image fails due to missing pull access.

I think we'll have to merge this and keep using it to see if it catches every relevant case. At least the most common case - pull failure - is now recognizable.