### PR TITLE
chore: re-introduce separate types for ifEventIsMissing

### DIFF
--- a/pkg/eventsourcingdb/ifeventismissingduringobserve/documentation.go
+++ b/pkg/eventsourcingdb/ifeventismissingduringobserve/documentation.go
@@ -1,0 +1,2 @@
+// Package ifeventismissingduringobserve provides a single enum for the fromLatestEvent option.
+package ifeventismissingduringobserve

--- a/pkg/eventsourcingdb/ifeventismissingduringobserve/if_event_is_missing.go
+++ b/pkg/eventsourcingdb/ifeventismissingduringobserve/if_event_is_missing.go
@@ -1,9 +1,8 @@
-package eventsourcingdb
+package ifeventismissingduringobserve
 
 type IfEventIsMissing string
 
 const (
-	ReadNothing    IfEventIsMissing = "read-nothing"
 	ReadEverything IfEventIsMissing = "read-everything"
 	WaitForEvent   IfEventIsMissing = "wait-for-event"
 )

--- a/pkg/eventsourcingdb/ifeventismissingduringread/documentation.go
+++ b/pkg/eventsourcingdb/ifeventismissingduringread/documentation.go
@@ -1,0 +1,2 @@
+// Package ifeventismissingduringread provides a single enum for the fromLatestEvent option.
+package ifeventismissingduringread

--- a/pkg/eventsourcingdb/ifeventismissingduringread/if_event_is_missing.go
+++ b/pkg/eventsourcingdb/ifeventismissingduringread/if_event_is_missing.go
@@ -1,0 +1,8 @@
+package ifeventismissingduringread
+
+type IfEventIsMissing string
+
+const (
+	ReadEverything IfEventIsMissing = "read-everything"
+	ReadNothing    IfEventIsMissing = "read-nothing"
+)

--- a/pkg/eventsourcingdb/observe_events_options.go
+++ b/pkg/eventsourcingdb/observe_events_options.go
@@ -2,8 +2,8 @@ package eventsourcingdb
 
 import (
 	"errors"
-	"fmt"
 	"github.com/thenativeweb/eventsourcingdb-client-golang/pkg/eventsourcingdb/event"
+	"github.com/thenativeweb/eventsourcingdb-client-golang/pkg/eventsourcingdb/ifeventismissingduringobserve"
 	"strconv"
 )
 
@@ -22,9 +22,9 @@ func ObserveNonRecursively() ObserveRecursivelyOption {
 }
 
 type observeFromLatestEvent struct {
-	Subject          string           `json:"subject"`
-	Type             string           `json:"type"`
-	IfEventIsMissing IfEventIsMissing `json:"ifEventIsMissing"`
+	Subject          string                                         `json:"subject"`
+	Type             string                                         `json:"type"`
+	IfEventIsMissing ifeventismissingduringobserve.IfEventIsMissing `json:"ifEventIsMissing"`
 }
 
 type observeEventsOptions struct {
@@ -36,17 +36,6 @@ type observeEventsOptions struct {
 type ObserveEventsOption struct {
 	apply func(options *observeEventsOptions) error
 	name  string
-}
-
-func validateIfEventIsMissingForObserveEvents(value IfEventIsMissing) error {
-	switch value {
-	case ReadEverything:
-		fallthrough
-	case WaitForEvent:
-		return nil
-	default:
-		return fmt.Errorf("%q is not a valid value for ifEventIsMissing, it must be either %q or %q", value, ReadEverything, WaitForEvent)
-	}
 }
 
 func ObserveFromLowerBoundID(lowerBoundID string) ObserveEventsOption {
@@ -72,7 +61,7 @@ func ObserveFromLowerBoundID(lowerBoundID string) ObserveEventsOption {
 	}
 }
 
-func ObserveFromLatestEvent(subject, eventType string, ifEventIsMissing IfEventIsMissing) ObserveEventsOption {
+func ObserveFromLatestEvent(subject, eventType string, ifEventIsMissing ifeventismissingduringobserve.IfEventIsMissing) ObserveEventsOption {
 	return ObserveEventsOption{
 		apply: func(options *observeEventsOptions) error {
 			if options.LowerBoundID != nil {
@@ -82,9 +71,6 @@ func ObserveFromLatestEvent(subject, eventType string, ifEventIsMissing IfEventI
 				return err
 			}
 			if err := event.ValidateType(eventType); err != nil {
-				return err
-			}
-			if err := validateIfEventIsMissingForObserveEvents(ifEventIsMissing); err != nil {
 				return err
 			}
 

--- a/pkg/eventsourcingdb/observe_events_test.go
+++ b/pkg/eventsourcingdb/observe_events_test.go
@@ -9,6 +9,7 @@ import (
 	"github.com/thenativeweb/eventsourcingdb-client-golang/pkg/errors"
 	"github.com/thenativeweb/eventsourcingdb-client-golang/pkg/eventsourcingdb"
 	"github.com/thenativeweb/eventsourcingdb-client-golang/pkg/eventsourcingdb/event"
+	"github.com/thenativeweb/eventsourcingdb-client-golang/pkg/eventsourcingdb/ifeventismissingduringobserve"
 	"net/http"
 	"testing"
 
@@ -159,7 +160,7 @@ func TestObserveEvents(t *testing.T) {
 			eventsourcingdb.ObserveFromLatestEvent(
 				"/users/loggedIn",
 				events.PrefixEventType("loggedin"),
-				eventsourcingdb.ReadEverything,
+				ifeventismissingduringobserve.ReadEverything,
 			),
 		)
 
@@ -231,7 +232,7 @@ func TestObserveEvents(t *testing.T) {
 			"/",
 			eventsourcingdb.ObserveRecursively(),
 			eventsourcingdb.ObserveFromLowerBoundID("0"),
-			eventsourcingdb.ObserveFromLatestEvent("/", "com.foo.bar", eventsourcingdb.WaitForEvent),
+			eventsourcingdb.ObserveFromLatestEvent("/", "com.foo.bar", ifeventismissingduringobserve.WaitForEvent),
 		)
 
 		result := <-results
@@ -281,7 +282,7 @@ func TestObserveEvents(t *testing.T) {
 			context.Background(),
 			"/",
 			eventsourcingdb.ObserveRecursively(),
-			eventsourcingdb.ObserveFromLatestEvent("", "com.foo.bar", eventsourcingdb.WaitForEvent),
+			eventsourcingdb.ObserveFromLatestEvent("", "com.foo.bar", ifeventismissingduringobserve.WaitForEvent),
 		)
 
 		result := <-results
@@ -298,7 +299,7 @@ func TestObserveEvents(t *testing.T) {
 			context.Background(),
 			"/",
 			eventsourcingdb.ObserveRecursively(),
-			eventsourcingdb.ObserveFromLatestEvent("/", ".bar", eventsourcingdb.WaitForEvent),
+			eventsourcingdb.ObserveFromLatestEvent("/", ".bar", ifeventismissingduringobserve.WaitForEvent),
 		)
 
 		result := <-results

--- a/pkg/eventsourcingdb/read_events_options.go
+++ b/pkg/eventsourcingdb/read_events_options.go
@@ -2,8 +2,8 @@ package eventsourcingdb
 
 import (
 	"errors"
-	"fmt"
 	"github.com/thenativeweb/eventsourcingdb-client-golang/pkg/eventsourcingdb/event"
+	"github.com/thenativeweb/eventsourcingdb-client-golang/pkg/eventsourcingdb/ifeventismissingduringread"
 	"strconv"
 )
 
@@ -22,9 +22,9 @@ func ReadNonRecursively() ReadRecursivelyOption {
 }
 
 type readFromLatestEvent struct {
-	Subject          string           `json:"subject"`
-	Type             string           `json:"type"`
-	IfEventIsMissing IfEventIsMissing `json:"ifEventIsMissing"`
+	Subject          string                                      `json:"subject"`
+	Type             string                                      `json:"type"`
+	IfEventIsMissing ifeventismissingduringread.IfEventIsMissing `json:"ifEventIsMissing"`
 }
 
 type readEventsOptions struct {
@@ -38,17 +38,6 @@ type readEventsOptions struct {
 type ReadEventsOption struct {
 	apply func(options *readEventsOptions) error
 	name  string
-}
-
-func validateIfEventIsMissingForReadEvents(value IfEventIsMissing) error {
-	switch value {
-	case ReadEverything:
-		fallthrough
-	case ReadNothing:
-		return nil
-	default:
-		return fmt.Errorf("%q is not a valid value for ifEventIsMissing, it must be either %q or %q", value, ReadEverything, ReadNothing)
-	}
 }
 
 func ReadChronologically() ReadEventsOption {
@@ -117,7 +106,7 @@ func ReadUntilUpperBoundID(upperBoundID string) ReadEventsOption {
 	}
 }
 
-func ReadFromLatestEvent(subject, eventType string, ifEventIsMissing IfEventIsMissing) ReadEventsOption {
+func ReadFromLatestEvent(subject, eventType string, ifEventIsMissing ifeventismissingduringread.IfEventIsMissing) ReadEventsOption {
 	return ReadEventsOption{
 		apply: func(options *readEventsOptions) error {
 			if options.LowerBoundID != nil {
@@ -127,9 +116,6 @@ func ReadFromLatestEvent(subject, eventType string, ifEventIsMissing IfEventIsMi
 				return err
 			}
 			if err := event.ValidateType(eventType); err != nil {
-				return err
-			}
-			if err := validateIfEventIsMissingForReadEvents(ifEventIsMissing); err != nil {
 				return err
 			}
 

--- a/pkg/eventsourcingdb/read_events_test.go
+++ b/pkg/eventsourcingdb/read_events_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/thenativeweb/eventsourcingdb-client-golang/pkg/errors"
 	"github.com/thenativeweb/eventsourcingdb-client-golang/pkg/eventsourcingdb"
 	"github.com/thenativeweb/eventsourcingdb-client-golang/pkg/eventsourcingdb/event"
+	"github.com/thenativeweb/eventsourcingdb-client-golang/pkg/eventsourcingdb/ifeventismissingduringread"
 	"net/http"
 	"testing"
 )
@@ -151,7 +152,7 @@ func TestReadEvents(t *testing.T) {
 			eventsourcingdb.ReadFromLatestEvent(
 				"/users/loggedIn",
 				events.PrefixEventType("loggedIn"),
-				eventsourcingdb.ReadEverything,
+				ifeventismissingduringread.ReadEverything,
 			),
 		)
 
@@ -250,7 +251,7 @@ func TestReadEvents(t *testing.T) {
 			"/",
 			eventsourcingdb.ReadRecursively(),
 			eventsourcingdb.ReadFromLowerBoundID("0"),
-			eventsourcingdb.ReadFromLatestEvent("/", "com.foo.bar", eventsourcingdb.ReadEverything),
+			eventsourcingdb.ReadFromLatestEvent("/", "com.foo.bar", ifeventismissingduringread.ReadEverything),
 		)
 
 		result := <-results
@@ -334,7 +335,7 @@ func TestReadEvents(t *testing.T) {
 			context.Background(),
 			"/",
 			eventsourcingdb.ReadRecursively(),
-			eventsourcingdb.ReadFromLatestEvent("", "com.foo.bar", eventsourcingdb.ReadNothing),
+			eventsourcingdb.ReadFromLatestEvent("", "com.foo.bar", ifeventismissingduringread.ReadNothing),
 		)
 
 		result := <-results
@@ -351,7 +352,7 @@ func TestReadEvents(t *testing.T) {
 			context.Background(),
 			"/",
 			eventsourcingdb.ReadRecursively(),
-			eventsourcingdb.ReadFromLatestEvent("/", ".bar", eventsourcingdb.ReadNothing),
+			eventsourcingdb.ReadFromLatestEvent("/", ".bar", ifeventismissingduringread.ReadNothing),
 		)
 
 		result := <-results


### PR DESCRIPTION
While working on the python client, I had a idea for better type safety.