### PR TITLE
fix: increase scanner buffer size to 100KB for large payloads

### DIFF
--- a/eventsourcingdb/read_events_test.go
+++ b/eventsourcingdb/read_events_test.go
@@ -3,6 +3,7 @@ package eventsourcingdb_test
 import (
 	"context"
 	"encoding/json"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -99,6 +100,47 @@ func TestReadEvents(t *testing.T) {
 		}
 
 		assert.Len(t, eventsRead, 2)
+	})
+
+	t.Run("reads huge event", func(t *testing.T) {
+		ctx := context.Background()
+
+		imageVersion, err := internal.GetImageVersionFromDockerfile()
+		require.NoError(t, err)
+
+		container := eventsourcingdb.NewContainer().WithImageTag(imageVersion)
+		container.Start(ctx)
+		defer container.Stop(ctx)
+
+		client, err := container.GetClient(ctx)
+		require.NoError(t, err)
+
+		firstEvent := eventsourcingdb.EventCandidate{
+			Source:  "https://www.eventsourcingdb.io",
+			Subject: "/test",
+			Type:    "io.eventsourcingdb.test",
+			Data: map[string]any{
+				"value": strings.Repeat("x", 64*1024),
+			},
+		}
+
+		_, err = client.WriteEvents(
+			[]eventsourcingdb.EventCandidate{
+				firstEvent,
+			},
+			nil,
+		)
+		require.NoError(t, err)
+
+		for _, err := range client.ReadEvents(
+			ctx,
+			"/test",
+			eventsourcingdb.ReadEventsOptions{
+				Recursive: false,
+			},
+		) {
+			assert.NoError(t, err)
+		}
 	})
 
 	t.Run("reads recursively", func(t *testing.T) {

--- a/internal/unmarshal_ndjson.go
+++ b/internal/unmarshal_ndjson.go
@@ -16,6 +16,11 @@ type Line struct {
 func UnmarshalNDJSON(ctx context.Context, r io.Reader) iter.Seq2[Line, error] {
 	return func(yield func(Line, error) bool) {
 		scanner := bufio.NewScanner(r)
+		// By default, bufio.Scanner has a maximum token size of 64KB.
+		// Since the event payload alone can reach 64KB, we increase the scanner's
+		// buffer size to accommodate the payload plus its metadata.
+		buf := make([]byte, 0, 100*1024)
+		scanner.Buffer(buf, 100*1024)
 
 		for scanner.Scan() {
 			select {


### PR DESCRIPTION
By default, bufio.Scanner is limited to 64KB. I increase this to 100KB to ensure events with up to 64KB of payload plus metadata can be processed without running into token size limits.

Adds a test to validate the behavior with larger events.